### PR TITLE
chore: add Umami analytics tracking

### DIFF
--- a/algorithm/SICP.html
+++ b/algorithm/SICP.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>SICP</title>
 </head>
 

--- a/algorithm/SICP2.html
+++ b/algorithm/SICP2.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>sicp chapter2</title>
 </head>
 

--- a/algorithm/arr_diff/index.html
+++ b/algorithm/arr_diff/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>alg test</title>

--- a/algorithm/prime/index.html
+++ b/algorithm/prime/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title></title>
 </head>
 

--- a/algorithm/show_sort/index.html
+++ b/algorithm/show_sort/index.html
@@ -3,6 +3,14 @@
 <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>show sort</title>
     <style type="text/css">
     * {

--- a/algorithm/sort/index.html
+++ b/algorithm/sort/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <!-- <meta viewport> -->
     meta:vp

--- a/algorithm/sort/sort.html
+++ b/algorithm/sort/sort.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>sort</title>
 </head>

--- a/algorithm/sort/sortTest.html
+++ b/algorithm/sort/sortTest.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>sort test</title>

--- a/animations/album/index.html
+++ b/animations/album/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <!-- <meta name="viewport" content="width=device-width, initial-scale=1"> -->

--- a/animations/circle/index.html
+++ b/animations/circle/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" charset="utf-8">
     <title>circle</title>
     <style type="text/css" media="screen">

--- a/animations/float_mask/direct.html
+++ b/animations/float_mask/direct.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/animations/float_mask/index.html
+++ b/animations/float_mask/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/animations/icon_align/index.html
+++ b/animations/icon_align/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>icon alignment</title>
     <style type="text/css" media="screen">

--- a/animations/macdock/index.html
+++ b/animations/macdock/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/animations/menu/index.html
+++ b/animations/menu/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>手风琴</title>

--- a/animations/next_pic/index.html
+++ b/animations/next_pic/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>next pic</title>

--- a/animations/slide_with_progress/index.html
+++ b/animations/slide_with_progress/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>带进度条的幻灯片</title>

--- a/animations/touch_demo/index.html
+++ b/animations/touch_demo/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/animations/typing/index.html
+++ b/animations/typing/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/css3/center/index.html
+++ b/css3/center/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>居中</title>
     <style>
     * {

--- a/css3/date_chart/index.html
+++ b/css3/date_chart/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title></title>
     <style type="text/css">
     canvas {

--- a/css3/flex/index.html
+++ b/css3/flex/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>css3 flex</title>
     <style type="text/css">
     .wrapper {

--- a/css3/return_money/index.html
+++ b/css3/return_money/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <title>利息计算器</title>

--- a/css3/rotate/index.html
+++ b/css3/rotate/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>锤子官网效果</title>
     <style type="text/css">
     body {

--- a/framework/angular_return_money/index.html
+++ b/framework/angular_return_money/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <title>Angular还款利息计算器</title>

--- a/framework/echart/echart.html
+++ b/framework/echart/echart.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>echart</title>
     <link rel="stylesheet" type="text/css" href="../../css/normalize.css">

--- a/framework/learn_angular/learn_angular.html
+++ b/framework/learn_angular/learn_angular.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>learn angular</title>
     <style type="text/css" media="screen">

--- a/framework/learn_angular/ng_comments/index.html
+++ b/framework/learn_angular/ng_comments/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>angular留言板</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/framework/learn_angular/ng_route/index.html
+++ b/framework/learn_angular/ng_route/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>路由试验</title>

--- a/framework/learn_angular/ng_signup/index.html
+++ b/framework/learn_angular/ng_signup/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>注册界面</title>
     <script src="../../../script/angular.min.js"></script>

--- a/framework/learn_jQuery/learn_jquery.html
+++ b/framework/learn_jQuery/learn_jquery.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>echart</title>
     <link rel="stylesheet" type="text/css" href="../../css/normalize.css">

--- a/framework/learn_node/server/index.html
+++ b/framework/learn_node/server/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/framework/plug_in/plug_in.html
+++ b/framework/plug_in/plug_in.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>plug in test</title>

--- a/framework/react/index.html
+++ b/framework/react/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>learn react</title>
     <meta charset="utf-8">
     <style type="text/css">

--- a/framework/react_return_money/index.html
+++ b/framework/react_return_money/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta name="charset" content="urf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>还款利息计算器</title>

--- a/framework/react_tictactoe/index.html
+++ b/framework/react_tictactoe/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <title>tic tac toe</title>
     <link rel="stylesheet" type="text/css" href="game.css">

--- a/framework/require_js/index.html
+++ b/framework/require_js/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">

--- a/framework/return_money/index.html
+++ b/framework/return_money/index.html
@@ -4,6 +4,14 @@
 <link rel="stylesheet" type="text/css" href="">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/framework/vue_return_money/index.html
+++ b/framework/vue_return_money/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <title>vue利息计算器</title>
     <link rel="stylesheet" href="return_money.css">

--- a/framework/vue_return_money/vue_test.html
+++ b/framework/vue_return_money/vue_test.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <title>vue test</title>
     <script src='../../script/vue.js'></script>

--- a/framework/vue_return_money2/index.html
+++ b/framework/vue_return_money2/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <title>还款利息计算器vue</title>

--- a/index-old.html
+++ b/index-old.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <title>小桑前端作品展示</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <title>小桑前端作品展示</title>

--- a/js_summary/test.html
+++ b/js_summary/test.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>test</title>

--- a/js_summary/width_top_left/index.html
+++ b/js_summary/width_top_left/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>width-top-left</title>

--- a/layout/jingdong/index.html
+++ b/layout/jingdong/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>京东</title>

--- a/layout/jingdong/test.html
+++ b/layout/jingdong/test.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>test</title>

--- a/learn/deepClone/index.html
+++ b/learn/deepClone/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>deep clone</title>
 </head>
 

--- a/learn/es6/es6.html
+++ b/learn/es6/es6.html
@@ -3,6 +3,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title></title>
     <script type="text/javascript">
     'use strict';

--- a/learn/interview/index.html
+++ b/learn/interview/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>面试题</title>
     <style>
     body {

--- a/learn/myQuery/index.html
+++ b/learn/myQuery/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>my jquery</title>
     <style type="text/css">
     li {

--- a/learn/viewport/index.html
+++ b/learn/viewport/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>viewport test</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/2048/2048.html
+++ b/pages/2048/2048.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>2048</title>
 	<link rel="stylesheet" href="2048.css">

--- a/pages/2048/box_test.html
+++ b/pages/2048/box_test.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>Document</title>
 	<style>

--- a/pages/2048new/index.html
+++ b/pages/2048new/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <title>2048game</title>
     <link rel="stylesheet" type="text/css" href="game.css">

--- a/pages/360spin/index.html
+++ b/pages/360spin/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>360spin</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/ad_fixed/ad_fixed.html
+++ b/pages/ad_fixed/ad_fixed.html
@@ -6,6 +6,14 @@
 
 <!-- <html lang="en"> -->
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>对联广告</title>
     <link rel="stylesheet" type="text/css" href="typo.css">

--- a/pages/animation_framework/animation.html
+++ b/pages/animation_framework/animation.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 <meta charset="utf-8">
     <title>animation</title>
     <style type="text/css" media="screen">

--- a/pages/animation_framework2/animation.html
+++ b/pages/animation_framework2/animation.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 <meta charset="utf-8">
     <title>animation</title>
     <style type="text/css" media="screen">

--- a/pages/buy_house/index.html
+++ b/pages/buy_house/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <!-- <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"> -->
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/buy_house/vue_test.html
+++ b/pages/buy_house/vue_test.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>vue test</title>

--- a/pages/cable_name/cable_name.html
+++ b/pages/cable_name/cable_name.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 	<title>电缆型号解析</title>

--- a/pages/cable_type_finder/cable_type_finder.html
+++ b/pages/cable_type_finder/cable_type_finder.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>Document</title>
 </head>

--- a/pages/calendar/简易日历.html
+++ b/pages/calendar/简易日历.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>简易日历</title>
 	<link rel="stylesheet" href="../../css/clear.css">

--- a/pages/click_scroll/index.html
+++ b/pages/click_scroll/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>click_scroll</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/clock/index.html
+++ b/pages/clock/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>clock</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/clock_animation/clock.html
+++ b/pages/clock_animation/clock.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/pages/comments_board/comments.html
+++ b/pages/comments_board/comments.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>留言板</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/count_down/index.html
+++ b/pages/count_down/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>count_down</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/count_down_sale/index.html
+++ b/pages/count_down_sale/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>拍卖</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/count_down_sale2/index.html
+++ b/pages/count_down_sale2/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>拍卖</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/css_sprite/css_sprite.html
+++ b/pages/css_sprite/css_sprite.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>CSS Sprite特效</title>
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">

--- a/pages/custom_scroll_bar/custom_scroll_bar.html
+++ b/pages/custom_scroll_bar/custom_scroll_bar.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <title>自定义滚动条</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/date_picker/date_picker.html
+++ b/pages/date_picker/date_picker.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>date choose</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="date_picker.css">

--- a/pages/date_picker2/date_picker.html
+++ b/pages/date_picker2/date_picker.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>date choose</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="date_picker.css">

--- a/pages/date_picker_jquery/date_packer.html
+++ b/pages/date_picker_jquery/date_packer.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>date choose</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="date_picker.css">

--- a/pages/date_picker_oop/date_packer.html
+++ b/pages/date_picker_oop/date_packer.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>date choose</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="date_picker.css">

--- a/pages/date_picker_oop_new/date_packer.html
+++ b/pages/date_picker_oop_new/date_packer.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>date choose</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="date_picker.css">

--- a/pages/discuz/index.html
+++ b/pages/discuz/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>discuz</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/drag/drag.html
+++ b/pages/drag/drag.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>drag</title>
     <link rel="stylesheet" href="drag.css">

--- a/pages/furnitureV1.0/index.html
+++ b/pages/furnitureV1.0/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>meizu V2.0</title>
 	<link rel="stylesheet" href="css/clear.css">

--- a/pages/furnitureV2.0/full_screen.html
+++ b/pages/furnitureV2.0/full_screen.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>bootstrap full screen</title>
 	<link rel="stylesheet" href="css/bootstrap-theme.css">

--- a/pages/furnitureV2.0/spinner.html
+++ b/pages/furnitureV2.0/spinner.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
   <meta charset="UTF-8">
   <title>Document</title>
   <link rel="stylesheet" href="css/bootstrap-theme.css">

--- a/pages/hao123/index.html
+++ b/pages/hao123/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>web收藏夹</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/idea_factory/index.html
+++ b/pages/idea_factory/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/key_move/key_move.html
+++ b/pages/key_move/key_move.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>key move</title>
     <style type="text/css" media="screen">

--- a/pages/magnify_glassV2/magnify.html
+++ b/pages/magnify_glassV2/magnify.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>Magnifying glass</title>
     <link rel="stylesheet" type="text/css" href="normalize.css">

--- a/pages/mobile/index.html
+++ b/pages/mobile/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE HTML>
 <html lang="zh-CN">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">

--- a/pages/my_page/frequency.html
+++ b/pages/my_page/frequency.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/my_page/index.html
+++ b/pages/my_page/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/my_page/name.html
+++ b/pages/my_page/name.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/namer/index.html
+++ b/pages/namer/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>你的名字</title>
     <meta charset="utf-8">
     <!-- <meta name='viewport' content="with=device-width,initial-scale = 1,user-scalable=no"> -->

--- a/pages/nav/index.html
+++ b/pages/nav/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>nav</title>
 	<!-- <link rel="stylesheet" type="text/css" href="style.css"> -->

--- a/pages/nav_menu/nav_menu.html
+++ b/pages/nav_menu/nav_menu.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 	<title>横向菜单</title>

--- a/pages/pic_scroll/index.html
+++ b/pages/pic_scroll/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>图片滚动</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/pinyin_converter/index.html
+++ b/pages/pinyin_converter/index.html
@@ -1,1 +1,9 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="X-UA-Compatible" content="ie=edge"><title>人名转拼音</title><link rel="shortcut icon" href="favicon.png"><link href="index.eada9f618d1e6c05e5bf51c7b8a2a2e6.css" rel="stylesheet"></head><body><div class="wrapper"><h1>人名转拼音</h1><form class="mode"><div class="left"><fieldset class="letter-mode-selector"></fieldset></div><div class="right"><fieldset class="mode-selector"></fieldset></div></form><div class="io"><div class="left"><p>输入</p><textarea name="input" id="input" cols="30" rows="10" placeholder="请输入人名, 用空格,回车,逗号来分隔名字"></textarea></div><div class="right"><p>输出</p><textarea name="output" id="output" cols="30" rows="10"></textarea></div></div><button class="btn-go">转换</button></div><script type="text/javascript" src="index.cceb932d20397eba3ed0.js"></script></body></html>
+<!DOCTYPE html><html lang="en"><head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="X-UA-Compatible" content="ie=edge"><title>人名转拼音</title><link rel="shortcut icon" href="favicon.png"><link href="index.eada9f618d1e6c05e5bf51c7b8a2a2e6.css" rel="stylesheet"></head><body><div class="wrapper"><h1>人名转拼音</h1><form class="mode"><div class="left"><fieldset class="letter-mode-selector"></fieldset></div><div class="right"><fieldset class="mode-selector"></fieldset></div></form><div class="io"><div class="left"><p>输入</p><textarea name="input" id="input" cols="30" rows="10" placeholder="请输入人名, 用空格,回车,逗号来分隔名字"></textarea></div><div class="right"><p>输出</p><textarea name="output" id="output" cols="30" rows="10"></textarea></div></div><button class="btn-go">转换</button></div><script type="text/javascript" src="index.cceb932d20397eba3ed0.js"></script></body></html>

--- a/pages/qq.com/index.html
+++ b/pages/qq.com/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 	<title>腾讯网</title>

--- a/pages/random_quote/random_quote.html
+++ b/pages/random_quote/random_quote.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>random quote</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/resize_box/resize_box.html
+++ b/pages/resize_box/resize_box.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <title>box resize</title>
     <style type="text/css" media="screen">

--- a/pages/rich_edit/blank.html
+++ b/pages/rich_edit/blank.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>Document</title>
 </head>

--- a/pages/rich_edit/rich_edit.html
+++ b/pages/rich_edit/rich_edit.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>富文本编辑器</title>
 	<link rel="stylesheet" type="text/css" href="rich_edit.css">

--- a/pages/shopping_cart/shopping_cart.html
+++ b/pages/shopping_cart/shopping_cart.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 	<title>完整购物车</title>

--- a/pages/slide/slide.html
+++ b/pages/slide/slide.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>slide</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/slide_to_unlock/slide_to_unlock.html
+++ b/pages/slide_to_unlock/slide_to_unlock.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>slide to unlock</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/slide_to_unlock_pack/slide_to_unlock.html
+++ b/pages/slide_to_unlock_pack/slide_to_unlock.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>slide to unlock</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/slide_with_animations/slide.html
+++ b/pages/slide_with_animations/slide.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/pages/slide_with_animations/slide_fade.html
+++ b/pages/slide_with_animations/slide_fade.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/pages/slide_with_animations/slide_smooth.html
+++ b/pages/slide_with_animations/slide_smooth.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/pages/slide_with_animations/slide_up_down.html
+++ b/pages/slide_with_animations/slide_up_down.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/pages/star_grade/index.html
+++ b/pages/star_grade/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>star grade</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/table_verify/index.html
+++ b/pages/table_verify/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
 	<title>js表单验证</title>

--- a/pages/tabs/tabs.html
+++ b/pages/tabs/tabs.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>选项卡</title>
 	<link rel="stylesheet" href="clear.css">

--- a/pages/tabs2.0/tabs2.0.html
+++ b/pages/tabs2.0/tabs2.0.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>选项卡
 	</title>

--- a/pages/tabs3.0/tabs3.0.html
+++ b/pages/tabs3.0/tabs3.0.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>选项卡
 	</title>

--- a/pages/tabs4.0/tabs4.0.html
+++ b/pages/tabs4.0/tabs4.0.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>选项卡
 	</title>

--- a/pages/test/index.html
+++ b/pages/test/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>test</title>
 </head>

--- a/pages/top10_tab/index.html
+++ b/pages/top10_tab/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>star grade</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/pages/two_key/two_key.html
+++ b/pages/two_key/two_key.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="UTF-8">
     <title>two_key</title>
     <style>

--- a/pages/waterfall/test.html
+++ b/pages/waterfall/test.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>test</title>
 	<style>

--- a/pages/waterfall/waterfall.html
+++ b/pages/waterfall/waterfall.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
 	<meta charset="UTF-8">
 	<title>瀑布流</title>
 	<link rel="stylesheet" type="text/css" href="style.css">

--- a/plug_in/colorful_time/index.html
+++ b/plug_in/colorful_time/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>colorfulTime demo</title>

--- a/plug_in/date_picker/date_packer.html
+++ b/plug_in/date_picker/date_packer.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <title>date choose</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="date_picker.css">

--- a/plug_in/date_picker/demo.html
+++ b/plug_in/date_picker/demo.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>date picker plug-in demo</title>

--- a/plug_in/slide_to_unlock/index.html
+++ b/plug_in/slide_to_unlock/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title></title>

--- a/plug_in/table_plug_in/index.html
+++ b/plug_in/table_plug_in/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>test plug in</title>

--- a/tech/ajax/index.html
+++ b/tech/ajax/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>ajax test</title>

--- a/tech/cookie/index.html
+++ b/tech/cookie/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>cookie test</title>

--- a/tech/custom_event/index.html
+++ b/tech/custom_event/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>自定义事件</title>

--- a/tech/ie_compat/index.html
+++ b/tech/ie_compat/index.html
@@ -7,6 +7,14 @@
 <!--<![endif]-->
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <title>IE兼容</title>
     <link rel="stylesheet" type="text/css" href="style.css">

--- a/tech/jsonp/index.html
+++ b/tech/jsonp/index.html
@@ -2,6 +2,14 @@
 <html>
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name='viewport' content="width=device-width,initial-scale=1">
     <title>jsonp</title>

--- a/tech/optimize_web/index.html
+++ b/tech/optimize_web/index.html
@@ -2,6 +2,14 @@
 <html lang="en">
 
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content=" FILL ME IN ">

--- a/tech/optimize_web/project-2048.html
+++ b/tech/optimize_web/project-2048.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content=" FILL ME IN ">

--- a/tech/optimize_web/project-mobile.html
+++ b/tech/optimize_web/project-mobile.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content=" FILL ME IN ">

--- a/tech/optimize_web/project-webperf.html
+++ b/tech/optimize_web/project-webperf.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content=" FILL ME IN ">

--- a/tech/optimize_web/views/pizza.html
+++ b/tech/optimize_web/views/pizza.html
@@ -1,6 +1,14 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<script
+  defer
+  src="https://cloud.umami.is/script.js"
+  data-website-id="e01c9f78-4607-4e60-b01c-77c8190b12b4"
+  data-domains="holynova.github.io"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+></script>
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/bootstrap-grid.css">
 </head>


### PR DESCRIPTION
## Summary
- add the shared Umami Cloud tracker to the root site and its 134 non-empty legacy HTML pages
- keep search terms and URL fragments excluded from collection
- preserve the empty legacy placeholder page unchanged

## Validation
- `git diff --check`
- 135 published HTML files contain the tracker

This is the top-50 GitHub Pages analytics rollout for the profile Pages repository.